### PR TITLE
fix: fix bug with embeds not loading w/o images

### DIFF
--- a/src/DiscordEmbed.svelte
+++ b/src/DiscordEmbed.svelte
@@ -33,7 +33,7 @@
 
   let imageUrl = findAndExtract("og:image", "content");
 
-  if (!imageUrl.startsWith("http") && !imageUrl.startsWith("file")) {
+  if (imageUrl && !imageUrl.startsWith("http") && !imageUrl.startsWith("file")) {
     imageUrl = new URL(imageUrl, url).href;
   }
   let imageWidthProperty = findAndExtract("og:image:width", "content") ?? 80;


### PR DESCRIPTION
Didn't work on https://vitejs.dev/, should work now.

![](https://get.snaz.in/5U3umYo.png)